### PR TITLE
Bugfix versions comparison + include pre-release

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ var SemverResolver = exports.SemverResolver = function () {
           if (dependencyLibrary) {
             if (!dependencyLibrary.maxSatisfying) {
               var range = dependencyLibrary.range;
-              var maxSatisfying = _semver2.default.maxSatisfying(versions, range);
+              var maxSatisfying = _semver2.default.maxSatisfying(versions, range, {includePrerelease: true});
               if (maxSatisfying === null) {
                 var backtrackedDueTo = dependencyLibrary.backtrackedDueTo;
                 var constrainingLibrary = 'root';
@@ -198,7 +198,7 @@ var SemverResolver = exports.SemverResolver = function () {
             version: maxSatisfying
           };
         }
-        if (maxSatisfying < lowestMaxSatisfying.version) {
+        if (_semver2.default.lt(maxSatisfying, lowestMaxSatisfying.version)) {
           lowestMaxSatisfying.parent = parent;
           lowestMaxSatisfying.version = maxSatisfying;
         }
@@ -213,7 +213,7 @@ var SemverResolver = exports.SemverResolver = function () {
       _lodash2.default.forOwn(dependencyLibraries, function (dependencyLibrary, parent) {
         if (parent !== constrainingParent) {
           var range = dependencyLibrary.range;
-          if (!_semver2.default.satisfies(version, range)) {
+          if (!_semver2.default.satisfies(version, range, {includePrerelease: true})) {
             // check if parent is root as root
             // cannot be backtracked
             var constrainingState = state[constrainingParent];


### PR DESCRIPTION
Versions where compared as strings instead of using semver methods, causing weird results (specially when using pre-release or build tags)